### PR TITLE
Accept base_url in #store_user_details

### DIFF
--- a/lib/cwds/authentication.rb
+++ b/lib/cwds/authentication.rb
@@ -18,9 +18,9 @@ module Cwds
       token_response.body if token_response.status == 200      
     end
 
-    def self.store_user_details_from_token(token)
+    def self.store_user_details_from_token(token, authentication_api_base_url)
       return unless token.present?
-      user_details_repsonse = Faraday.get(token_validation_url(token, AUTHENTICATION_API_BASE_URL))
+      user_details_repsonse = Faraday.get(token_validation_url(token, authentication_api_base_url))
       user_details_repsonse.body   if user_details_repsonse.status == 200
     end
 


### PR DESCRIPTION
I will be needing to examine user profiles from `tokens` in https://github.com/ca-cwds/dashboard.

From the looks of it, maybe this code block got missed in a refactor? (`AUTHENTICATION_API_BASE_URL` is an uninitialized constant) and similar methods in the module do not have this signature.